### PR TITLE
Switch makepad to dev, use rustls for reqwest, cleanup packaging workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,10 +18,6 @@ on:
         description: "Build iOS app"
         type: boolean
         default: true
-      build_openharmony:
-        description: "Build OpenHarmony HAP"
-        type: boolean
-        default: false
       release_tag:
         description: "Release tag (optional, supports __VERSION__)"
         type: string
@@ -103,8 +99,7 @@ jobs:
             - Linux (x86_64)
             - Windows (x86_64)
             - Android (arm64)
-            - iOS (arm64)
-            - OpenHarmony (arm64)' }}
+            - iOS (arm64)' }}
           draft: ${{ inputs.release_draft || false }}
           prerelease: ${{ inputs.prerelease || false }}
         env:
@@ -147,22 +142,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ inputs.args }}
           packager_formats: ${{ matrix.packager_formats }}
-          tagName: ${{ needs.create-release.outputs.release_tag }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dora-studio-${{ matrix.name }}
-          path: |
-            target/release/*.dmg
-            target/release/*.app
-            target/release/*.deb
-            target/release/*.AppImage
-            target/release/*.exe
-            target/release/*.msi
-          if-no-files-found: ignore
 
   android:
     name: Android
@@ -181,16 +163,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           args: --target aarch64-linux-android ${{ inputs.args }}
-          tagName: ${{ needs.create-release.outputs.release_tag }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dora-studio-Android
-          path: |
-            target/makepad-android-project/*.apk
-          if-no-files-found: ignore
 
   ios:
     name: iOS
@@ -215,14 +189,5 @@ jobs:
           APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
           APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
         with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           args: --target aarch64-apple-ios ${{ inputs.args }}
-          tagName: ${{ needs.create-release.outputs.release_tag }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dora-studio-iOS
-          path: |
-            target/**/*.app
-            target/**/*.ipa
-          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 /target/
 **/*.rs.bk
+dist/
 
 # IDE
 .idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,8 @@ version = 4
 
 [[package]]
 name = "ab_glyph_rasterizer"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+version = "0.1.8"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 
 [[package]]
 name = "adler2"
@@ -131,6 +130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,16 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -223,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dora-studio"
 version = "0.1.0"
 dependencies = [
@@ -241,13 +245,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
+name = "downcast-rs"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "equivalent"
@@ -316,21 +317,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -446,8 +432,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -457,9 +445,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -581,22 +571,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -618,11 +593,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -851,6 +824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "makepad-android-state"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,8 +840,8 @@ dependencies = [
 
 [[package]]
 name = "makepad-derive-live"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -870,16 +849,16 @@ dependencies = [
 
 [[package]]
 name = "makepad-derive-wasm-bridge"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
 
 [[package]]
 name = "makepad-derive-widget"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -887,45 +866,97 @@ dependencies = [
 
 [[package]]
 name = "makepad-draw"
-version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
  "makepad-html",
+ "makepad-live-id",
  "makepad-platform",
  "makepad-rustybuzz",
  "makepad-vector",
  "png",
  "sdfer",
- "ttf-parser 0.25.1",
+ "ttf-parser",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-segmentation",
 ]
 
 [[package]]
+name = "makepad-error-log"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-micro-serde",
+]
+
+[[package]]
+name = "makepad-fonts-chinese-bold"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-chinese-bold-2"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-chinese-regular"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-chinese-regular-2"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-emoji"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
 name = "makepad-futures"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 
 [[package]]
 name = "makepad-futures-legacy"
-version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 
 [[package]]
 name = "makepad-html"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-live-id",
 ]
 
 [[package]]
 name = "makepad-http"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-script",
+]
 
 [[package]]
 name = "makepad-jni-sys"
@@ -935,8 +966,8 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 
 [[package]]
 name = "makepad-live-compiler"
-version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -945,24 +976,24 @@ dependencies = [
 
 [[package]]
 name = "makepad-live-id"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-live-id-macros",
 ]
 
 [[package]]
 name = "makepad-live-id-macros"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
 
 [[package]]
 name = "makepad-live-tokenizer"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -971,21 +1002,21 @@ dependencies = [
 
 [[package]]
 name = "makepad-math"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-micro-serde",
 ]
 
 [[package]]
 name = "makepad-micro-proc-macro"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 
 [[package]]
 name = "makepad-micro-serde"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -993,25 +1024,26 @@ dependencies = [
 
 [[package]]
 name = "makepad-micro-serde-derive"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
 
 [[package]]
 name = "makepad-objc-sys"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 
 [[package]]
 name = "makepad-platform"
-version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "bitflags 2.10.0",
  "hilog-sys",
  "makepad-android-state",
+ "makepad-error-log",
  "makepad-futures",
  "makepad-futures-legacy",
  "makepad-http",
@@ -1023,20 +1055,23 @@ dependencies = [
  "napi-ohos",
  "ohos-sys",
  "smallvec",
+ "wayland-client",
+ "wayland-egl",
+ "wayland-protocols",
  "windows",
  "windows-core",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
+ "makepad-ttf-parser",
  "smallvec",
- "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -1044,26 +1079,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "makepad-script"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-error-log",
+ "makepad-live-id",
+ "makepad-math",
+ "makepad-script-derive",
+ "smallvec",
+]
+
+[[package]]
+name = "makepad-script-derive"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+dependencies = [
+ "makepad-micro-proc-macro",
+]
+
+[[package]]
 name = "makepad-shader-compiler"
-version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-live-compiler",
 ]
 
 [[package]]
+name = "makepad-ttf-parser"
+version = "0.21.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
+
+[[package]]
 name = "makepad-vector"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
+ "makepad-ttf-parser",
  "resvg",
- "ttf-parser 0.21.1",
 ]
 
 [[package]]
 name = "makepad-wasm-bridge"
-version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1071,11 +1131,16 @@ dependencies = [
 
 [[package]]
 name = "makepad-widgets"
-version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
+ "makepad-fonts-chinese-bold",
+ "makepad-fonts-chinese-bold-2",
+ "makepad-fonts-chinese-regular",
+ "makepad-fonts-chinese-regular-2",
+ "makepad-fonts-emoji",
  "makepad-html",
  "makepad-zune-jpeg",
  "makepad-zune-png",
@@ -1086,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -1094,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -1102,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -1113,12 +1178,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1191,23 +1250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,50 +1279,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1335,6 +1333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1369,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1446,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "regex"
@@ -1413,29 +1513,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1443,6 +1540,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1489,6 +1587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1520,6 +1625,7 @@ version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4910321ebe4151be888e35fe062169554e74aad01beafed60410131420ceffbc"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1547,42 +1653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
+name = "scoped-tls"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fd75ebc7c721a70d202c7cdd2beb108bbe5dfaaea68e06aff4de2f4cc240ed"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
+source = "git+https://github.com/makepad/makepad?branch=dev#8350b6bf86f603ad55441bf82d05feb51f4fd383"
 
 [[package]]
 name = "serde"
@@ -1751,27 +1830,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1840,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1821,6 +1899,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,16 +1937,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -1973,11 +2056,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#f27e2062bfdca5ddda8ba759d465cb5c2f5cd99e"
-
-[[package]]
-name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
@@ -2094,12 +2172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,6 +2255,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+dependencies = [
+ "bitflags 2.10.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-egl"
+version = "0.32.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2c9ef35f3b2e11d5709d8e75dc1e7e064fd8eec5d705d56073fafca85de854"
+dependencies = [
+ "wayland-backend",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2332,25 @@ checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2210,7 +2371,7 @@ checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -2243,41 +2404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -2305,21 +2437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2357,12 +2474,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2375,12 +2486,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2390,12 +2495,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2423,12 +2522,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2438,12 +2531,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2459,12 +2546,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2474,12 +2555,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2555,6 +2630,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Dora Studio - AI Chat Application built with Makepad"
 
 [dependencies]
 # UI Framework (pure Rust)
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
 # Serialization (pure Rust)
 serde = { version = "1", features = ["derive"] }
@@ -22,7 +22,7 @@ anyhow = "1"
 # Async Runtime for native
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 # HTTP client for native
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # WASM-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,7 +95,7 @@ impl MatchEvent for App {
 
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
         // Handle DataflowTable actions using direct button click checks
-        let table = self.ui.dataflow_table(id!(dataflow_table));
+        let table = self.ui.dataflow_table(ids!(dataflow_table));
 
         if table.refresh_clicked(actions) {
             log!("[App] Refresh button clicked - refreshing dataflows");
@@ -150,7 +150,7 @@ impl AppMain for App {
 impl App {
     fn refresh_dataflows(&mut self, cx: &mut Cx) {
         log!("[App] refresh_dataflows called");
-        let table = self.ui.dataflow_table(id!(dataflow_table));
+        let table = self.ui.dataflow_table(ids!(dataflow_table));
         table.set_loading(cx);
 
         // Execute dora list command

--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -185,14 +185,17 @@ impl Widget for ChatScreen {
 
 impl WidgetMatchEvent for ChatScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.view.button(id!(send_button)).clicked(&actions) {
+        if self.view.button(ids!(send_button)).clicked(&actions) {
             self.send_message(cx);
         }
 
-        if let Some(text) = self.view.text_input(id!(message_input)).returned(&actions) {
-            if !text.is_empty() {
-                self.send_message(cx);
-            }
+        if self
+            .view
+            .text_input(ids!(message_input))
+            .returned(&actions)
+            .is_some()
+        {
+            self.send_message(cx);
         }
     }
 }
@@ -214,7 +217,7 @@ impl ChatScreen {
                 };
 
                 let item = list.item(cx, item_id, template);
-                item.label(id!(label)).set_text(cx, &msg.content);
+                item.label(ids!(label)).set_text(cx, &msg.content);
                 item.draw_all(cx, &mut Scope::empty());
             } else if self.is_loading && item_id == self.messages.len() {
                 // Render loading indicator (only one, right after messages)
@@ -231,12 +234,12 @@ impl ChatScreen {
         } else {
             format!("{} messages", self.messages.len())
         };
-        self.view.label(id!(status_label)).set_text(cx, &status);
+        self.view.label(ids!(status_label)).set_text(cx, &status);
         self.redraw(cx);
     }
 
     fn send_message(&mut self, cx: &mut Cx) {
-        let input = self.view.text_input(id!(message_input));
+        let input = self.view.text_input(ids!(message_input));
         let text = input.text();
         if text.trim().is_empty() {
             return;

--- a/src/dataflow/dataflow_table.rs
+++ b/src/dataflow/dataflow_table.rs
@@ -458,7 +458,7 @@ impl WidgetMatchEvent for DataflowTable {
         );
 
         // Handle refresh button
-        let refresh_btn = self.view.button(id!(refresh_button));
+        let refresh_btn = self.view.button(ids!(refresh_button));
         let btn_exists = refresh_btn.borrow().is_some();
         log!("[DataflowTable] refresh_button exists: {}", btn_exists);
 
@@ -471,12 +471,12 @@ impl WidgetMatchEvent for DataflowTable {
         }
 
         // Handle row action buttons via PortalList
-        let table_list = self.view.portal_list(id!(table_list));
+        let table_list = self.view.portal_list(ids!(table_list));
         for (item_id, item) in table_list.items_with_actions(actions) {
             if item_id < self.dataflows.len() {
                 let uuid = self.dataflows[item_id].uuid.clone();
 
-                if item.button(id!(stop_button)).clicked(actions) {
+                if item.button(ids!(stop_button)).clicked(actions) {
                     cx.widget_action(
                         self.widget_uid(),
                         &scope.path,
@@ -484,7 +484,7 @@ impl WidgetMatchEvent for DataflowTable {
                     );
                 }
 
-                if item.button(id!(destroy_button)).clicked(actions) {
+                if item.button(ids!(destroy_button)).clicked(actions) {
                     cx.widget_action(
                         self.widget_uid(),
                         &scope.path,
@@ -492,7 +492,7 @@ impl WidgetMatchEvent for DataflowTable {
                     );
                 }
 
-                if item.button(id!(logs_button)).clicked(actions) {
+                if item.button(ids!(logs_button)).clicked(actions) {
                     cx.widget_action(
                         self.widget_uid(),
                         &scope.path,
@@ -512,7 +512,7 @@ impl DataflowTable {
         self.loading_state = TableLoadingState::Idle;
         log!("[DataflowTable] calling redraw");
         // Redraw the PortalList specifically to ensure it updates
-        self.view.portal_list(id!(table_list)).redraw(cx);
+        self.view.portal_list(ids!(table_list)).redraw(cx);
         self.redraw(cx);
     }
 
@@ -520,7 +520,7 @@ impl DataflowTable {
     pub fn set_from_ndjson(&mut self, cx: &mut Cx, ndjson: &str) {
         self.dataflows = DataflowInfo::parse_ndjson(ndjson);
         self.loading_state = TableLoadingState::Idle;
-        self.view.portal_list(id!(table_list)).redraw(cx);
+        self.view.portal_list(ids!(table_list)).redraw(cx);
         self.redraw(cx);
     }
 
@@ -528,14 +528,14 @@ impl DataflowTable {
     pub fn set_from_json(&mut self, cx: &mut Cx, json: &str) {
         self.dataflows = DataflowInfo::parse_json_array(json);
         self.loading_state = TableLoadingState::Idle;
-        self.view.portal_list(id!(table_list)).redraw(cx);
+        self.view.portal_list(ids!(table_list)).redraw(cx);
         self.redraw(cx);
     }
 
     /// Set loading state
     pub fn set_loading(&mut self, cx: &mut Cx) {
         self.loading_state = TableLoadingState::Loading;
-        self.view.portal_list(id!(table_list)).redraw(cx);
+        self.view.portal_list(ids!(table_list)).redraw(cx);
         self.redraw(cx);
     }
 
@@ -543,7 +543,7 @@ impl DataflowTable {
     pub fn set_error(&mut self, cx: &mut Cx, message: &str) {
         self.loading_state = TableLoadingState::Error;
         self.error_message = message.to_string();
-        self.view.portal_list(id!(table_list)).redraw(cx);
+        self.view.portal_list(ids!(table_list)).redraw(cx);
         self.redraw(cx);
     }
 
@@ -567,7 +567,7 @@ impl DataflowTable {
         self.dataflows.clear();
         self.selected_row = None;
         self.loading_state = TableLoadingState::Idle;
-        self.view.portal_list(id!(table_list)).redraw(cx);
+        self.view.portal_list(ids!(table_list)).redraw(cx);
         self.redraw(cx);
     }
 
@@ -622,11 +622,11 @@ impl DataflowTable {
                 let item = list.item(cx, item_id, template);
 
                 // Set row data
-                item.label(id!(uuid_label)).set_text(cx, &df.uuid_short());
-                item.label(id!(name_label)).set_text(cx, &df.name);
-                item.label(id!(status_label)).set_text(cx, &df.status);
-                item.label(id!(cpu_label)).set_text(cx, &df.cpu_formatted());
-                item.label(id!(memory_label))
+                item.label(ids!(uuid_label)).set_text(cx, &df.uuid_short());
+                item.label(ids!(name_label)).set_text(cx, &df.name);
+                item.label(ids!(status_label)).set_text(cx, &df.status);
+                item.label(ids!(cpu_label)).set_text(cx, &df.cpu_formatted());
+                item.label(ids!(memory_label))
                     .set_text(cx, &df.memory_formatted());
 
                 log!(
@@ -707,7 +707,7 @@ impl DataflowTableRef {
     /// Check if the refresh button was clicked (direct check, bypasses action system)
     pub fn refresh_clicked(&self, actions: &Actions) -> bool {
         if let Some(inner) = self.borrow() {
-            inner.view.button(id!(refresh_button)).clicked(actions)
+            inner.view.button(ids!(refresh_button)).clicked(actions)
         } else {
             false
         }
@@ -716,10 +716,10 @@ impl DataflowTableRef {
     /// Check if a stop button was clicked, returns the UUID if so
     pub fn stop_clicked(&self, actions: &Actions) -> Option<String> {
         if let Some(inner) = self.borrow() {
-            let table_list = inner.view.portal_list(id!(table_list));
+            let table_list = inner.view.portal_list(ids!(table_list));
             for (item_id, item) in table_list.items_with_actions(actions) {
                 if item_id < inner.dataflows.len() {
-                    if item.button(id!(stop_button)).clicked(actions) {
+                    if item.button(ids!(stop_button)).clicked(actions) {
                         return Some(inner.dataflows[item_id].uuid.clone());
                     }
                 }
@@ -731,10 +731,10 @@ impl DataflowTableRef {
     /// Check if a destroy button was clicked, returns the UUID if so
     pub fn destroy_clicked(&self, actions: &Actions) -> Option<String> {
         if let Some(inner) = self.borrow() {
-            let table_list = inner.view.portal_list(id!(table_list));
+            let table_list = inner.view.portal_list(ids!(table_list));
             for (item_id, item) in table_list.items_with_actions(actions) {
                 if item_id < inner.dataflows.len() {
-                    if item.button(id!(destroy_button)).clicked(actions) {
+                    if item.button(ids!(destroy_button)).clicked(actions) {
                         return Some(inner.dataflows[item_id].uuid.clone());
                     }
                 }
@@ -746,10 +746,10 @@ impl DataflowTableRef {
     /// Check if a logs button was clicked, returns the UUID if so
     pub fn logs_clicked(&self, actions: &Actions) -> Option<String> {
         if let Some(inner) = self.borrow() {
-            let table_list = inner.view.portal_list(id!(table_list));
+            let table_list = inner.view.portal_list(ids!(table_list));
             for (item_id, item) in table_list.items_with_actions(actions) {
                 if item_id < inner.dataflows.len() {
-                    if item.button(id!(logs_button)).clicked(actions) {
+                    if item.button(ids!(logs_button)).clicked(actions) {
                         return Some(inner.dataflows[item_id].uuid.clone());
                     }
                 }


### PR DESCRIPTION
## PR Content

### 1. Switch current makepad branch: `rik` to `dev`, the `dev` branch is the latest branch for makepad.

No changes were made to any core logic code; this update solely adds support for the latest features of makepad on the dev branch.

The key changes :`id!()` -> `ids!()`

### 2. Use rustls for reqwest

This change switches reqwest to use rustls instead of the default native-tls.

The default reqwest features enable native-tls, which pulls in openssl-sys. This causes build failures when cross-compiling (e.g. macOS → aarch64-linux-android), because OpenSSL for the target platform is not available by default.

By disabling default features and enabling rustls-tls, we:
	• Avoid the OpenSSL dependency entirely
	• Fix Android cross-compilation failures
	• Keep TLS support fully functional using a pure-Rust backend

This approach is recommended for cross-platform targets (Android / iOS / WASM) and aligns with current Rust ecosystem best practices.

### 3. Cleanup packaging workflow

Improvement: No need to upload artifacts separately after each job.

