### PR TITLE
Improve feedback for Stop/Kill on Finished/Failed dataflows (#74)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -234,12 +234,38 @@ impl MatchEvent for App {
 
         if let Some(uuid) = table.stop_clicked(actions) {
             log!("[App] Stop button clicked for {}", uuid);
-            self.stop_dataflow(cx, &uuid);
+
+            // If dataflow is not running, show a UX message instead of calling stop.
+            if let Some(status) = table.status_for_uuid(&uuid) {
+                if !status.eq_ignore_ascii_case("running") {
+                    self.ui
+                        .label(ids!(connection_label))
+                        .set_text(cx, "No action: dataflow is already finished/failed");
+                } else {
+                    self.stop_dataflow(cx, &uuid);
+                }
+            } else {
+                // Fallback: if we can't find the status, keep existing behavior.
+                self.stop_dataflow(cx, &uuid);
+            }
         }
 
         if let Some(uuid) = table.destroy_clicked(actions) {
             log!("[App] Destroy button clicked for {}", uuid);
-            self.destroy_dataflow(cx, &uuid);
+
+            // If dataflow is not running, show a UX message instead of calling destroy.
+            if let Some(status) = table.status_for_uuid(&uuid) {
+                if !status.eq_ignore_ascii_case("running") {
+                    self.ui
+                        .label(ids!(connection_label))
+                        .set_text(cx, "No action: dataflow is already finished/failed");
+                } else {
+                    self.destroy_dataflow(cx, &uuid);
+                }
+            } else {
+                // Fallback: if we can't find the status, keep existing behavior.
+                self.destroy_dataflow(cx, &uuid);
+            }
         }
 
         if let Some(uuid) = table.logs_clicked(actions) {

--- a/src/dataflow/dataflow_table.rs
+++ b/src/dataflow/dataflow_table.rs
@@ -652,6 +652,15 @@ impl DataflowTableRef {
         }
     }
 
+    /// Get the status string for a given UUID, if present in the table.
+    pub fn status_for_uuid(&self, uuid: &str) -> Option<String> {
+        if let Some(inner) = self.borrow() {
+            inner.get_dataflow_by_uuid(uuid).map(|df| df.status.clone())
+        } else {
+            None
+        }
+    }
+
     /// Check if a DataflowTableAction was triggered
     pub fn action(&self, actions: &Actions) -> Option<DataflowTableAction> {
         if let Some(item) = actions.find_widget_action(self.widget_uid()) {


### PR DESCRIPTION
#This PR fixes **#74: “No acknowledgment when clicking Stop or Kill on Finished or Failed dataflows”** by adding clear UI feedback instead of silently doing nothing or re-running backend commands on already-completed workflows.

- **Before**
  - Clicking **Stop** or **Kill** on a **Finished** or **Failed** dataflow gave **no acknowledgment** in the UI.
  - It was unclear whether the action ran, was ignored, or failed.

- **After**
  - The app **checks the dataflow status** before calling `dora_stop` / `dora_destroy`.
  - If the status is **not `Running`**, it **does not** call the Dora CLI and instead shows:
    - **“No action: dataflow is already finished/failed”** in the header.
  - For **Running** dataflows, Stop and Kill still behave exactly as before.

## Implementation Details

- **Dataflow status lookup**
  - Added `DataflowTableRef::status_for_uuid(&self, uuid: &str) -> Option<String>` to fetch the current status for a given dataflow UUID from the table’s `dataflows` list.

- **App-side behavior**
  - In `App::handle_actions`, for:
    - `table.stop_clicked(actions)`
    - `table.destroy_clicked(actions)`
  - The app now:
    - Uses `status_for_uuid` to read the status.
    - If status is **not** `"running"` (case-insensitive):
      - Skips `stop_dataflow` / `destroy_dataflow`.
      - Updates `connection_label` with:
        - **“No action: dataflow is already finished/failed”**.
    - If status **is** `"running"` or cannot be found:
      - Falls back to the previous behavior (call Dora, then refresh the table).

- **Important**
  - **Running workflows** are unchanged:
    - **Stop** → still calls `dora stop <id>`.
    - **Kill** → still calls `dora destroy <id>`.
  - Only **Finished/Failed/Stopped** workflows now short-circuit with a UX message instead of attempting another stop/kill.

## Testing

- **Running dataflow**
  - Start a dataflow so it shows **Running**.
  - Click **Stop** → dataflow stops / disappears as before.
  - Click **Kill** → dataflow is forcefully destroyed / cleaned up as before.

- **Finished dataflow**
  - Let a dataflow reach **Finished**.
  - Click **Stop** → no Dora call; header shows:
    - **“No action: dataflow is already finished/failed”**.
  - Click **Kill** → same behavior.

- **Failed dataflow**
  - Trigger a dataflow that ends in **Failed**.
  - Click **Stop** / **Kill** → no Dora call; same “No action” message.

> I have attached the one photo as well to showcase the thing here.
<img width="1899" height="1027" alt="image" src="https://github.com/user-attachments/assets/7f3a9888-d274-422a-9c3e-24db4508bfce" />
<img width="461" height="42" alt="image" src="https://github.com/user-attachments/assets/02ac3d8f-965f-4987-a5a6-3fb4d93963f5" />
