### PR TITLE
feat(llm): add LlmClient abstraction and Anthropic implementation (AI-01 / #49)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,12 +242,15 @@ name = "dora-studio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
+ "futures",
  "makepad-widgets",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-test",
  "uuid",
@@ -1391,7 +1405,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1412,7 +1426,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1429,7 +1443,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1844,11 +1858,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ serde_json = "1"
 
 # Error handling
 anyhow = "1"
+thiserror = "1"
+async-trait = "0.1"
+futures = "0.3"
 
 # Native-only dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
+use crate::llm::{AnthropicLlmClient, Context, LlmClient};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::tools::{execute_tool, get_dora_tools};
 #[cfg(target_arch = "wasm32")]
 use makepad_widgets::Cx;
@@ -160,75 +162,20 @@ pub fn submit_chat_request(messages: Vec<ChatMessage>) {
 }
 
 // ============================================================================
-// Claude API Request/Response Structures
+// WASM: minimal response types (simple API; no `llm` module on WASM)
 // ============================================================================
 
-/// Claude API request with tools (native only)
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Serialize)]
-struct ClaudeRequest {
-    model: String,
-    max_tokens: u32,
-    system: String,
-    messages: Vec<ClaudeMessage>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<ClaudeTool>,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Serialize, Clone)]
-struct ClaudeTool {
-    name: String,
-    description: String,
-    input_schema: serde_json::Value,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Serialize, Clone)]
-struct ClaudeMessage {
-    role: String,
-    content: ClaudeMessageContent,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Serialize, Clone)]
-#[serde(untagged)]
-enum ClaudeMessageContent {
-    Text(String),
-    Blocks(Vec<ContentBlock>),
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Serialize, Clone)]
-#[serde(tag = "type")]
-enum ContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: String,
-        name: String,
-        input: serde_json::Value,
-    },
-    #[serde(rename = "tool_result")]
-    ToolResult {
-        tool_use_id: String,
-        content: String,
-        #[serde(skip_serializing_if = "std::ops::Not::not")]
-        is_error: bool,
-    },
-}
-
-/// Claude API response structure
+#[cfg(target_arch = "wasm32")]
 #[derive(Deserialize, Debug)]
 #[allow(dead_code)]
 struct ClaudeResponse {
     content: Vec<ClaudeResponseContent>,
     stop_reason: Option<String>,
     #[serde(default)]
-    usage: Option<Usage>,
+    usage: Option<WasmUsage>,
 }
 
+#[cfg(target_arch = "wasm32")]
 #[derive(Deserialize, Debug)]
 #[allow(dead_code)]
 struct ClaudeResponseContent {
@@ -244,18 +191,21 @@ struct ClaudeResponseContent {
     input: Option<serde_json::Value>,
 }
 
+#[cfg(target_arch = "wasm32")]
 #[derive(Deserialize, Debug)]
 #[allow(dead_code)]
-struct Usage {
+struct WasmUsage {
     input_tokens: u32,
     output_tokens: u32,
 }
 
+#[cfg(target_arch = "wasm32")]
 #[derive(Deserialize)]
 struct ClaudeErrorResponse {
     error: ClaudeErrorDetail,
 }
 
+#[cfg(target_arch = "wasm32")]
 #[derive(Deserialize)]
 struct ClaudeErrorDetail {
     message: String,
@@ -348,7 +298,7 @@ async fn call_claude_api_simple(messages: Vec<ChatMessage>) -> ChatResponse {
 // Native API Call Implementation with Tool Loop
 // ============================================================================
 
-/// Call Claude API with tools support - implements the agentic loop
+/// Call Claude API with tools — agentic loop via [`LlmClient`](crate::llm::LlmClient).
 #[cfg(not(target_arch = "wasm32"))]
 async fn call_claude_api_with_tools(messages: Vec<ChatMessage>) -> ChatResponse {
     let api_key = get_api_key();
@@ -357,34 +307,33 @@ async fn call_claude_api_with_tools(messages: Vec<ChatMessage>) -> ChatResponse 
         return ChatResponse::Error("Please enter your Claude API key in the header".to_string());
     }
 
-    let client = reqwest::Client::new();
+    let last_user = match messages.last() {
+        Some(m) if m.role == MessageRole::User => m.content.clone(),
+        _ => {
+            return ChatResponse::Error(
+                "Invalid conversation: last message must be from the user".to_string(),
+            );
+        }
+    };
 
-    // Convert tools to Claude format
-    let tools: Vec<ClaudeTool> = get_dora_tools()
-        .into_iter()
-        .map(|t| ClaudeTool {
-            name: t.name,
-            description: t.description,
-            input_schema: t.input_schema,
-        })
-        .collect();
+    let tools = get_dora_tools();
+    let client = AnthropicLlmClient::new(api_key);
 
-    // Convert initial messages to Claude format
-    let mut claude_messages: Vec<ClaudeMessage> = messages
-        .iter()
-        .map(|m| ClaudeMessage {
-            role: match m.role {
-                MessageRole::User => "user".to_string(),
-                MessageRole::Assistant => "assistant".to_string(),
-            },
-            content: ClaudeMessageContent::Text(m.content.clone()),
-        })
-        .collect();
+    let mut ctx = Context::from_prior_chat_messages(
+        SYSTEM_PROMPT,
+        "claude-sonnet-4-20250514",
+        4096,
+        &messages,
+    );
 
-    // Collect all text responses and tool executions
+    let mut agent = match client.chat(&mut ctx, &last_user, &tools).await {
+        Ok(a) => a,
+        Err(e) => return ChatResponse::Error(e.to_string()),
+    };
+
     let mut final_response = String::new();
-    let mut iteration = 0;
-    const MAX_ITERATIONS: u32 = 10; // Prevent infinite loops
+    let mut iteration = 0u32;
+    const MAX_ITERATIONS: u32 = 10;
 
     loop {
         iteration += 1;
@@ -394,156 +343,47 @@ async fn call_claude_api_with_tools(messages: Vec<ChatMessage>) -> ChatResponse 
             break;
         }
 
-        let request = ClaudeRequest {
-            model: "claude-sonnet-4-20250514".to_string(),
-            max_tokens: 4096,
-            system: SYSTEM_PROMPT.to_string(),
-            messages: claude_messages.clone(),
-            tools: tools.clone(),
-        };
-
-        eprintln!("[API] Sending HTTP request...");
-        let result = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("Content-Type", "application/json")
-            .header("x-api-key", &api_key)
-            .header("anthropic-version", "2023-06-01")
-            .json(&request)
-            .send()
-            .await;
-
-        let response = match result {
-            Ok(resp) => resp,
-            Err(e) => return ChatResponse::Error(format!("Network error: {}", e)),
-        };
-
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-
-        if !status.is_success() {
-            return match serde_json::from_str::<ClaudeErrorResponse>(&body) {
-                Ok(error_response) => {
-                    ChatResponse::Error(format!("API Error: {}", error_response.error.message))
-                }
-                Err(_) => ChatResponse::Error(format!("API Error ({}): {}", status, body)),
-            };
-        }
-
-        let claude_response: ClaudeResponse = match serde_json::from_str(&body) {
-            Ok(r) => r,
-            Err(e) => {
-                return ChatResponse::Error(format!(
-                    "Failed to parse response: {}\nBody: {}",
-                    e, body
-                ))
-            }
-        };
-
-        // Process response content
-        let mut tool_uses: Vec<(String, String, serde_json::Value)> = Vec::new();
-        let mut has_text = false;
-
-        for content in &claude_response.content {
-            match content.content_type.as_str() {
-                "text" => {
-                    if let Some(text) = &content.text {
-                        if !text.is_empty() {
-                            if !final_response.is_empty() {
-                                final_response.push_str("\n\n");
-                            }
-                            final_response.push_str(text);
-                            has_text = true;
-                        }
-                    }
-                }
-                "tool_use" => {
-                    if let (Some(id), Some(name), Some(input)) =
-                        (&content.id, &content.name, &content.input)
-                    {
-                        tool_uses.push((id.clone(), name.clone(), input.clone()));
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        // Check if we should stop
-        let stop_reason = claude_response.stop_reason.as_deref().unwrap_or("");
-        if stop_reason == "end_turn" || (tool_uses.is_empty() && has_text) {
-            break;
-        }
-
-        // Execute tools if any
-        if !tool_uses.is_empty() {
-            // Build assistant message with tool uses
-            let tool_use_blocks: Vec<ContentBlock> = tool_uses
-                .iter()
-                .map(|(id, name, input)| ContentBlock::ToolUse {
-                    id: id.clone(),
-                    name: name.clone(),
-                    input: input.clone(),
-                })
-                .collect();
-
-            // Add any text that came with tool uses
-            let mut assistant_blocks: Vec<ContentBlock> = Vec::new();
-            for content in &claude_response.content {
-                if content.content_type == "text" {
-                    if let Some(text) = &content.text {
-                        if !text.is_empty() {
-                            assistant_blocks.push(ContentBlock::Text { text: text.clone() });
-                        }
-                    }
-                }
-            }
-            assistant_blocks.extend(tool_use_blocks);
-
-            claude_messages.push(ClaudeMessage {
-                role: "assistant".to_string(),
-                content: ClaudeMessageContent::Blocks(assistant_blocks),
-            });
-
-            // Execute tools and collect results
-            let mut tool_results: Vec<ContentBlock> = Vec::new();
-
-            for (id, name, input) in &tool_uses {
-                // Add tool execution info to response
+        if let Some(t) = &agent.text {
+            if !t.is_empty() {
                 if !final_response.is_empty() {
                     final_response.push_str("\n\n");
                 }
-                final_response.push_str(&format!("🔧 Executing: {}", name));
-
-                let result = execute_tool(name, id, input);
-
-                // Show result preview in final response
-                let preview = if result.content.len() > 200 {
-                    format!("{}...", &result.content[..200])
-                } else {
-                    result.content.clone()
-                };
-
-                if result.is_error {
-                    final_response.push_str(&format!("\n❌ Error: {}", preview));
-                } else {
-                    final_response.push_str(&format!("\n✅ Result: {}", preview));
-                }
-
-                tool_results.push(ContentBlock::ToolResult {
-                    tool_use_id: result.tool_use_id,
-                    content: result.content,
-                    is_error: result.is_error,
-                });
+                final_response.push_str(t);
             }
+        }
 
-            // Add tool results as user message
-            claude_messages.push(ClaudeMessage {
-                role: "user".to_string(),
-                content: ClaudeMessageContent::Blocks(tool_results),
-            });
-        } else {
-            // No tools and no clear end - break to avoid infinite loop
+        if agent.tool_calls.is_empty() {
             break;
         }
+
+        let mut pairs = Vec::new();
+        for call in &agent.tool_calls {
+            if !final_response.is_empty() {
+                final_response.push_str("\n\n");
+            }
+            final_response.push_str(&format!("🔧 Executing: {}", call.name));
+
+            let result = execute_tool(&call.name, &call.id, &call.arguments);
+
+            let preview = if result.content.len() > 200 {
+                format!("{}...", &result.content[..200])
+            } else {
+                result.content.clone()
+            };
+
+            if result.is_error {
+                final_response.push_str(&format!("\n❌ Error: {}", preview));
+            } else {
+                final_response.push_str(&format!("\n✅ Result: {}", preview));
+            }
+
+            pairs.push((call.clone(), result));
+        }
+
+        agent = match client.continue_with_results(&mut ctx, &pairs, &tools).await {
+            Ok(a) => a,
+            Err(e) => return ChatResponse::Error(e.to_string()),
+        };
     }
 
     if final_response.is_empty() {
@@ -556,6 +396,11 @@ async fn call_claude_api_with_tools(messages: Vec<ChatMessage>) -> ChatResponse 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    use crate::llm::anthropic::{
+        ClaudeErrorResponse, ClaudeMessage, ClaudeMessageContent, ClaudeRequest, ClaudeResponse,
+    };
 
     // ============================================================================
     // ChatMessage Tests
@@ -659,9 +504,10 @@ mod tests {
     }
 
     // ============================================================================
-    // Claude Response Structure Tests
+    // Claude Response Structure Tests (native: wire types live in `llm::anthropic`)
     // ============================================================================
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_claude_response_deserialization() {
         let json = r#"{"content":[{"type":"text","text":"Hello!"}]}"#;
@@ -670,6 +516,7 @@ mod tests {
         assert_eq!(response.content[0].text, Some("Hello!".to_string()));
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_claude_response_empty_content() {
         let json = r#"{"content":[]}"#;
@@ -677,6 +524,7 @@ mod tests {
         assert!(response.content.is_empty());
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_claude_error_response_deserialization() {
         let json = r#"{"error":{"message":"Invalid API key"}}"#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ pub mod app;
 pub mod chat;
 pub mod dataflow;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub mod llm;
+
 // Tools module only available on native platforms (uses shell commands)
 #[cfg(not(target_arch = "wasm32"))]
 pub mod tools;

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -1,0 +1,338 @@
+//! Anthropic Messages API — [`super::LlmClient`](super::LlmClient) for Claude.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::tools::ToolDefinition;
+
+use super::client::{LlmClient, StreamingLlmClient};
+use super::context::Context;
+use super::error::LlmError;
+use super::types::{AgentResponse, LlmStreamChunk, ToolCall};
+
+// ---------------------------------------------------------------------------
+// Wire types (Anthropic Messages API)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct ClaudeRequest {
+    pub model: String,
+    pub max_tokens: u32,
+    pub system: String,
+    pub messages: Vec<ClaudeMessage>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ClaudeTool>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct ClaudeTool {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct ClaudeMessage {
+    pub role: String,
+    pub content: ClaudeMessageContent,
+}
+
+#[derive(Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum ClaudeMessageContent {
+    Text(String),
+    Blocks(Vec<ContentBlock>),
+}
+
+#[derive(Serialize, Clone, Debug)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        #[serde(skip_serializing_if = "std::ops::Not::not")]
+        is_error: bool,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClaudeResponse {
+    pub content: Vec<ClaudeResponseContent>,
+    pub stop_reason: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub usage: Option<Usage>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClaudeResponseContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub input: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Usage {
+    #[allow(dead_code)]
+    pub input_tokens: u32,
+    #[allow(dead_code)]
+    pub output_tokens: u32,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClaudeErrorResponse {
+    pub error: ClaudeErrorDetail,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClaudeErrorDetail {
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
+
+const ANTHROPIC_URL: &str = "https://api.anthropic.com/v1/messages";
+
+/// Anthropic Claude [`LlmClient`] / [`StreamingLlmClient`].
+pub struct AnthropicLlmClient {
+    api_key: String,
+    http: reqwest::Client,
+}
+
+impl AnthropicLlmClient {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub fn api_key(&self) -> &str {
+        &self.api_key
+    }
+
+    async fn post_messages(
+        &self,
+        ctx: &Context,
+        tools: &[ClaudeTool],
+    ) -> Result<ClaudeResponse, LlmError> {
+        if self.api_key.is_empty() {
+            return Err(LlmError::MissingApiKey);
+        }
+
+        let request = ClaudeRequest {
+            model: ctx.model.clone(),
+            max_tokens: ctx.max_tokens,
+            system: ctx.system_prompt.clone(),
+            messages: ctx.messages.clone(),
+            tools: tools.to_vec(),
+        };
+
+        let result = self
+            .http
+            .post(ANTHROPIC_URL)
+            .header("Content-Type", "application/json")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| LlmError::Http(e.to_string()))?;
+
+        let status = result.status();
+        let body = result
+            .text()
+            .await
+            .map_err(|e| LlmError::Http(e.to_string()))?;
+
+        if !status.is_success() {
+            return match serde_json::from_str::<ClaudeErrorResponse>(&body) {
+                Ok(e) => Err(LlmError::Api {
+                    status: status.as_u16(),
+                    message: e.error.message,
+                }),
+                Err(_) => Err(LlmError::Api {
+                    status: status.as_u16(),
+                    message: body,
+                }),
+            };
+        }
+
+        serde_json::from_str(&body)
+            .map_err(|e| LlmError::InvalidResponse(format!("parse error: {e}; body: {body}")))
+    }
+
+    fn tools_to_claude(tools: &[ToolDefinition]) -> Vec<ClaudeTool> {
+        tools
+            .iter()
+            .map(|t| ClaudeTool {
+                name: t.name.clone(),
+                description: t.description.clone(),
+                input_schema: t.input_schema.clone(),
+            })
+            .collect()
+    }
+
+    fn response_to_assistant_and_agent(
+        resp: &ClaudeResponse,
+    ) -> Result<(ClaudeMessage, AgentResponse), LlmError> {
+        let mut text_parts: Vec<String> = Vec::new();
+        let mut tool_calls: Vec<ToolCall> = Vec::new();
+        let mut blocks: Vec<ContentBlock> = Vec::new();
+
+        for content in &resp.content {
+            match content.content_type.as_str() {
+                "text" => {
+                    if let Some(t) = &content.text {
+                        if !t.is_empty() {
+                            text_parts.push(t.clone());
+                            blocks.push(ContentBlock::Text { text: t.clone() });
+                        }
+                    }
+                }
+                "tool_use" => {
+                    if let (Some(id), Some(name), Some(input)) =
+                        (&content.id, &content.name, &content.input)
+                    {
+                        tool_calls.push(ToolCall {
+                            id: id.clone(),
+                            name: name.clone(),
+                            arguments: input.clone(),
+                        });
+                        blocks.push(ContentBlock::ToolUse {
+                            id: id.clone(),
+                            name: name.clone(),
+                            input: input.clone(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let text = if text_parts.is_empty() {
+            None
+        } else {
+            Some(text_parts.join("\n\n"))
+        };
+
+        let assistant_content = if blocks.is_empty() {
+            ClaudeMessageContent::Text(String::new())
+        } else if blocks.len() == 1 {
+            match &blocks[0] {
+                ContentBlock::Text { text } => ClaudeMessageContent::Text(text.clone()),
+                _ => ClaudeMessageContent::Blocks(blocks),
+            }
+        } else {
+            ClaudeMessageContent::Blocks(blocks)
+        };
+
+        let assistant = ClaudeMessage {
+            role: "assistant".to_string(),
+            content: assistant_content,
+        };
+
+        let agent = AgentResponse {
+            text,
+            tool_calls,
+            stop_reason: resp.stop_reason.clone(),
+        };
+
+        Ok((assistant, agent))
+    }
+}
+
+#[async_trait]
+impl LlmClient for AnthropicLlmClient {
+    async fn chat(
+        &self,
+        context: &mut Context,
+        message: &str,
+        tools: &[ToolDefinition],
+    ) -> Result<AgentResponse, LlmError> {
+        context.push_user_text(message);
+        let claude_tools = Self::tools_to_claude(tools);
+        let resp = self.post_messages(context, &claude_tools).await?;
+        let (assistant, agent) = Self::response_to_assistant_and_agent(&resp)?;
+        context.messages.push(assistant);
+        Ok(agent)
+    }
+
+    async fn continue_with_result(
+        &self,
+        context: &mut Context,
+        tool_call: &ToolCall,
+        result: &crate::tools::ToolResult,
+        tools: &[ToolDefinition],
+    ) -> Result<AgentResponse, LlmError> {
+        self.continue_with_results(context, &[(tool_call.clone(), result.clone())], tools)
+            .await
+    }
+
+    async fn continue_with_results(
+        &self,
+        context: &mut Context,
+        pairs: &[(ToolCall, crate::tools::ToolResult)],
+        tools: &[ToolDefinition],
+    ) -> Result<AgentResponse, LlmError> {
+        let tool_blocks: Vec<ContentBlock> = pairs
+            .iter()
+            .map(|(_call, tr)| ContentBlock::ToolResult {
+                tool_use_id: tr.tool_use_id.clone(),
+                content: tr.content.clone(),
+                is_error: tr.is_error,
+            })
+            .collect();
+
+        context.messages.push(ClaudeMessage {
+            role: "user".to_string(),
+            content: ClaudeMessageContent::Blocks(tool_blocks),
+        });
+
+        let claude_tools = Self::tools_to_claude(tools);
+        let resp = self.post_messages(context, &claude_tools).await?;
+        let (assistant, agent) = Self::response_to_assistant_and_agent(&resp)?;
+        context.messages.push(assistant);
+        Ok(agent)
+    }
+}
+
+#[async_trait]
+impl StreamingLlmClient for AnthropicLlmClient {
+    async fn chat_stream(
+        &self,
+        _context: &mut Context,
+        _message: &str,
+        _tools: &[ToolDefinition],
+    ) -> Result<futures::stream::BoxStream<'static, Result<LlmStreamChunk, LlmError>>, LlmError>
+    {
+        Err(LlmError::StreamingNotSupported)
+    }
+
+    async fn continue_with_result_stream(
+        &self,
+        _context: &mut Context,
+        _tool_call: &ToolCall,
+        _result: &crate::tools::ToolResult,
+        _tools: &[ToolDefinition],
+    ) -> Result<futures::stream::BoxStream<'static, Result<LlmStreamChunk, LlmError>>, LlmError>
+    {
+        Err(LlmError::StreamingNotSupported)
+    }
+}

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -1,0 +1,59 @@
+//! [`LlmClient`] — async trait for chat + tool continuation + optional streaming.
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use crate::tools::ToolDefinition;
+
+use super::context::Context;
+use super::error::LlmError;
+use super::types::{AgentResponse, LlmStreamChunk, ToolCall};
+
+/// Async LLM provider: one chat turn and tool-result continuation.
+#[async_trait]
+pub trait LlmClient: Send + Sync {
+    /// Append `message` as a user turn, run one model request, update `context`, return structured output.
+    async fn chat(
+        &self,
+        context: &mut Context,
+        message: &str,
+        tools: &[ToolDefinition],
+    ) -> Result<AgentResponse, LlmError>;
+
+    /// After executing **one** tool, append the tool result and request the next model turn.
+    /// `tools` must be the same schema as used in [`LlmClient::chat`](Self::chat) for this session.
+    async fn continue_with_result(
+        &self,
+        context: &mut Context,
+        tool_call: &ToolCall,
+        result: &crate::tools::ToolResult,
+        tools: &[ToolDefinition],
+    ) -> Result<AgentResponse, LlmError>;
+
+    /// After executing **multiple** tools from the same assistant turn, append all tool results in one user message (recommended for Anthropic).
+    async fn continue_with_results(
+        &self,
+        context: &mut Context,
+        pairs: &[(ToolCall, crate::tools::ToolResult)],
+        tools: &[ToolDefinition],
+    ) -> Result<AgentResponse, LlmError>;
+}
+
+/// Optional streaming API (providers may return [`LlmError::StreamingNotSupported`] until implemented).
+#[async_trait]
+pub trait StreamingLlmClient: Send + Sync {
+    async fn chat_stream(
+        &self,
+        context: &mut Context,
+        message: &str,
+        tools: &[ToolDefinition],
+    ) -> Result<BoxStream<'static, Result<LlmStreamChunk, LlmError>>, LlmError>;
+
+    async fn continue_with_result_stream(
+        &self,
+        context: &mut Context,
+        tool_call: &ToolCall,
+        result: &crate::tools::ToolResult,
+        tools: &[ToolDefinition],
+    ) -> Result<BoxStream<'static, Result<LlmStreamChunk, LlmError>>, LlmError>;
+}

--- a/src/llm/context.rs
+++ b/src/llm/context.rs
@@ -1,0 +1,71 @@
+//! Conversation state for LLM providers (native: Anthropic wire format).
+
+#[cfg(not(target_arch = "wasm32"))]
+use super::anthropic::ClaudeMessage;
+use crate::api::{ChatMessage, MessageRole};
+
+/// Mutable conversation state passed to [`super::LlmClient`](super::LlmClient).
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone)]
+pub struct Context {
+    pub system_prompt: String,
+    pub model: String,
+    pub max_tokens: u32,
+    pub(crate) messages: Vec<ClaudeMessage>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Context {
+    pub fn new(
+        system_prompt: impl Into<String>,
+        model: impl Into<String>,
+        max_tokens: u32,
+    ) -> Self {
+        Self {
+            system_prompt: system_prompt.into(),
+            model: model.into(),
+            max_tokens,
+            messages: Vec::new(),
+        }
+    }
+
+    /// Build context from all prior [`ChatMessage`] entries; the latest user turn is supplied to [`super::LlmClient::chat`](super::LlmClient::chat).
+    /// Prior turns only: if the last entry is a user message, it is **excluded** so it can be passed
+    /// as `message` to [`super::LlmClient::chat`](super::LlmClient::chat) (avoids duplicating the latest user line).
+    pub fn from_prior_chat_messages(
+        system_prompt: impl Into<String>,
+        model: impl Into<String>,
+        max_tokens: u32,
+        messages: &[ChatMessage],
+    ) -> Self {
+        let slice = if matches!(messages.last(), Some(m) if m.role == MessageRole::User) {
+            messages.len().saturating_sub(1)
+        } else {
+            messages.len()
+        };
+        let messages_claude: Vec<ClaudeMessage> = messages[..slice]
+            .iter()
+            .map(|m| ClaudeMessage {
+                role: match m.role {
+                    MessageRole::User => "user".to_string(),
+                    MessageRole::Assistant => "assistant".to_string(),
+                },
+                content: super::anthropic::ClaudeMessageContent::Text(m.content.clone()),
+            })
+            .collect();
+
+        Self {
+            system_prompt: system_prompt.into(),
+            model: model.into(),
+            max_tokens,
+            messages: messages_claude,
+        }
+    }
+
+    pub(crate) fn push_user_text(&mut self, text: &str) {
+        self.messages.push(ClaudeMessage {
+            role: "user".to_string(),
+            content: super::anthropic::ClaudeMessageContent::Text(text.to_string()),
+        });
+    }
+}

--- a/src/llm/error.rs
+++ b/src/llm/error.rs
@@ -1,0 +1,34 @@
+//! Structured errors for LLM providers.
+
+use thiserror::Error;
+
+/// Errors returned by [`crate::llm::LlmClient`](super::LlmClient) implementations.
+#[derive(Debug, Error)]
+pub enum LlmError {
+    #[error("API key is missing; set ANTHROPIC_API_KEY or configure the client")]
+    MissingApiKey,
+
+    #[error("HTTP request failed: {0}")]
+    Http(String),
+
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+
+    #[error("failed to parse model response: {0}")]
+    Deserialize(#[from] serde_json::Error),
+
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+
+    #[error("empty response from model")]
+    EmptyResponse,
+
+    #[error("maximum tool iterations ({0}) exceeded")]
+    MaxToolIterations(u32),
+
+    #[error("streaming is not supported for this provider")]
+    StreamingNotSupported,
+
+    #[error("conversation state error: {0}")]
+    Context(String),
+}

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,0 +1,28 @@
+//! LLM provider abstraction: async [`LlmClient`], Anthropic implementation, errors, and types.
+
+mod client;
+mod context;
+mod error;
+mod types;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod anthropic;
+
+pub use client::{LlmClient, StreamingLlmClient};
+pub use context::Context;
+pub use error::LlmError;
+pub use types::{AgentResponse, LlmStreamChunk, ToolCall};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use anthropic::AnthropicLlmClient;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::LlmError;
+
+    #[test]
+    fn llm_error_display_missing_key() {
+        let s = LlmError::MissingApiKey.to_string();
+        assert!(s.contains("API key"), "{}", s);
+    }
+}

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -1,0 +1,53 @@
+//! Shared types for LLM requests and responses.
+
+use serde::{Deserialize, Serialize};
+
+/// A tool invocation requested by the model (Anthropic `tool_use`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// One round-trip response from the model (text, tool calls, or both).
+#[derive(Debug, Clone, Default)]
+pub struct AgentResponse {
+    /// Assistant text segments in this turn (may be empty if only tools).
+    pub text: Option<String>,
+    /// Tool uses requested in this turn.
+    pub tool_calls: Vec<ToolCall>,
+    /// Provider stop reason when available (e.g. `end_turn`, `tool_use`).
+    pub stop_reason: Option<String>,
+}
+
+impl AgentResponse {
+    pub fn text_only(text: String) -> Self {
+        Self {
+            text: Some(text),
+            tool_calls: vec![],
+            stop_reason: None,
+        }
+    }
+
+    pub fn tool_calls_only(calls: Vec<ToolCall>) -> Self {
+        Self {
+            text: None,
+            tool_calls: calls,
+            stop_reason: None,
+        }
+    }
+
+    pub fn has_tool_calls(&self) -> bool {
+        !self.tool_calls.is_empty()
+    }
+}
+
+/// Streaming events for [`crate::llm::StreamingLlmClient`](super::StreamingLlmClient).
+#[derive(Debug, Clone)]
+pub enum LlmStreamChunk {
+    /// Incremental text delta.
+    TextDelta(String),
+    /// Model finished this stream (caller should not expect more chunks).
+    Done,
+}


### PR DESCRIPTION
## Summary

Implements **AI-01**: an async **`LlmClient`** provider abstraction so chat + tool use are not tied to raw HTTP in `api.rs`, plus a concrete **`AnthropicLlmClient`** for the existing Claude (Messages API) integration.

Closes / relates to: **#49** (AI-01)

## What changed

- **`src/llm/`** (native only)
  - **`LlmError`**: structured errors (`thiserror`) — missing key, HTTP, API errors, parse errors, streaming not supported, etc.
  - **`Context`**: conversation state for Anthropic wire format; **`from_prior_chat_messages`** builds history so the latest user turn is passed once to **`chat`** (avoids duplicating the last user line).
  - **`ToolCall`**, **`AgentResponse`**, **`LlmStreamChunk`**: shared agent types.
  - **`LlmClient`** (`async_trait`): **`chat`**, **`continue_with_result`** (single tool), **`continue_with_results`** (batch tool results in one user message — matches Anthropic).
  - **`StreamingLlmClient`**: optional streaming methods; Anthropic returns **`LlmError::StreamingNotSupported`** until SSE is implemented.
  - **`AnthropicLlmClient`**: request/response handling; Claude wire types live in **`llm::anthropic`** (exported for unit tests).
- **`api.rs`**
  - **`call_claude_api_with_tools`** refactored to use **`LlmClient`**: first **`chat`**, then loop with **`execute_tool`** + **`continue_with_results`**; same user-facing formatting as before (tool execution lines, previews).
  - **WASM**: unchanged “simple” no-tools path; minimal response types kept **`#[cfg(target_arch = "wasm32")]`** in `api.rs` ( **`llm` is not built on WASM** ).
- **`Cargo.toml`**: `async-trait`, `thiserror`, `futures`.
- **`lib.rs`**: `pub mod llm` behind **`#[cfg(not(target_arch = "wasm32"))]`**.

## Testing

- `cargo test --lib` — **106 passed** (includes `llm` tests and existing `api` tests; wire types tests use `llm::anthropic` on native).

## Manual / follow-up

- **Chat + real tool calling** requires **`ANTHROPIC_API_KEY`**; not exercised in CI. Reviewers with a key: quick smoke test (e.g. prompt that should trigger `dora_list` or another tool).
- **`MockLlmClient`** in `tests/mocks/` can be wired to **`LlmClient`** in a follow-up for integration tests without network.